### PR TITLE
update to 0.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,19 @@ source:
   sha256: b5fb09543a64a91165dfe85796759f9e415edc296beb4db33d1ecf7866a862bd
 
 build:
-  noarch: python
+  skip: True # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - setuptools >=42.0.0
+    - wheel
   run:
     - packaging >=19.0
-    - python >=3.7
+    - python
 
 test:
   imports:
@@ -33,8 +35,15 @@ test:
 about:
   home: https://github.com/FFY00/python-pyproject-metadata
   summary: PEP 621 metadata parsing
+  description: |
+    This project does not implement the parsing of pyproject.toml containing PEP 621 metadata.
+    Instead, given a Python data structure representing PEP 621 metadata (already parsed), 
+    it will validate this input and generate a PEP 643-compliant metadata file (e.g. PKG-INFO).
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  dev_url: https://github.com/FFY00/python-pyproject-metadata
+  doc_url: https://github.com/FFY00/python-pyproject-metadata/blob/main/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
New feedstock required for meson-python.

Changes:
- fork from conda-forge
- update about section
- remove noarch
- check dependencies

https://github.com/FFY00/python-pyproject-metadata
https://github.com/FFY00/python-pyproject-metadata/blob/main/pyproject.toml
https://github.com/FFY00/python-pyproject-metadata/blob/main/setup.cfg

https://concourse.build.corp.continuum.io/teams/main/pipelines/cbousseau_pyproject-metadata